### PR TITLE
fix: set ubuntu version to 22.04 to fix builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/toolbx/ubuntu-toolbox:24.04 as obs-studio-portable
+FROM quay.io/toolbx/ubuntu-toolbox:22.04 as obs-studio-portable
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \


### PR DESCRIPTION
This WILL fix builds, but obs-studio-portable will lose out on SRT and RIST support, but users can at least download and update the container again as the ubuntu version is supported.

There is no release for 24.04 yet

If wimpy does not release a new version of obs-portable within early next year then we can deprecate this image (people who still use it can still download and use it for as long github does not clean it up and it will keep updating fine through topgrade)

If wimpy does updates it upstream we lock to LTS containers only going forward i think.
I will try reach out to him and ask if there are any plans to update it.